### PR TITLE
inherit from `RuboCop::Cop::Base` instead of `RuboCop::Cop::Cop`

### DIFF
--- a/lib/rubocop/cop/norb/active_record_namespaced.rb
+++ b/lib/rubocop/cop/norb/active_record_namespaced.rb
@@ -40,7 +40,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ActiveRecordNamespaced < Cop
+      class ActiveRecordNamespaced < Base
         CONFIGS = {
           namespace: OpenStruct.new(key: 'ActiveRecordNamespace', default: :Ar),
           superclasses: OpenStruct.new(

--- a/lib/rubocop/cop/norb/active_record_through_business.rb
+++ b/lib/rubocop/cop/norb/active_record_through_business.rb
@@ -33,7 +33,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ActiveRecordThroughBusiness < Cop
+      class ActiveRecordThroughBusiness < Base
         MSG = 'Direct ActiveRecord calls should come from business objects.'
 
         def_node_matcher :const_name, <<-PATTERN

--- a/lib/rubocop/cop/norb/binary_operation.rb
+++ b/lib/rubocop/cop/norb/binary_operation.rb
@@ -11,7 +11,7 @@ module RuboCop
       # boolean operators: `&&`, `||`
       # and "spaceship" operator - `<=>`.
       #
-      class BinaryOperation < Cop
+      class BinaryOperation < Base
         MSG = 'This comparison operator logic is not allowed here.'
 
         COMPARISON_OPERATORS = %i[== === != eql? equal? =~ !~ < > <=> <= >=].freeze

--- a/lib/rubocop/cop/norb/branching_logic.rb
+++ b/lib/rubocop/cop/norb/branching_logic.rb
@@ -201,7 +201,7 @@ module RuboCop
       #       </ul>
       #     </menu>
       #   ERB
-      class BranchingLogic < Cop
+      class BranchingLogic < Base
         MSG = 'This branching logic is not allowed here.'
 
         def on_if(node)

--- a/lib/rubocop/cop/norb/misplaced_logic.rb
+++ b/lib/rubocop/cop/norb/misplaced_logic.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   # good
       #   # app/models/blog/comments.rb
       #
-      class MisplacedLogic < Cop
+      class MisplacedLogic < Base
         include RangeHelp
         MSG = 'Code should only be placed in %<exclude>s.'
 

--- a/lib/rubocop/cop/norb/one_controller_action_instance_variable.rb
+++ b/lib/rubocop/cop/norb/one_controller_action_instance_variable.rb
@@ -33,7 +33,7 @@ module RuboCop
       #     end
       #   end
       #
-      class OneControllerActionInstanceVariable < Cop
+      class OneControllerActionInstanceVariable < Base
         include DefNode
         MSG = '`%<action>s` instantiates more than one @instance variable.'
 

--- a/lib/rubocop/cop/norb/standard_restful_controller_actions.rb
+++ b/lib/rubocop/cop/norb/standard_restful_controller_actions.rb
@@ -29,7 +29,7 @@ module RuboCop
       #     end
       #   end
       #
-      class StandardRestfulControllerActions < Cop
+      class StandardRestfulControllerActions < Base
         include DefNode
 
         MSG = '`%<action>s` is not a standard RESTful controller action.'


### PR DESCRIPTION
Fixed deprecation warnings: Inheriting from RuboCop::Cop::Cop is deprecated. Use RuboCop::Cop::Base instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.